### PR TITLE
Fix lamp alignment

### DIFF
--- a/src/components/lamp/lampComponent.jsx
+++ b/src/components/lamp/lampComponent.jsx
@@ -14,7 +14,7 @@ export function LampDemo() {
           duration: 0.8,
           ease: "easeInOut",
         }}
-        className="mt-8 bg-gradient-to-br from-slate-300 to-slate-500 py-4 bg-clip-text text-center text-4xl font-medium tracking-tight text-transparent md:text-7xl">
+        className="bg-gradient-to-br from-slate-300 to-slate-500 py-4 bg-clip-text text-center text-4xl font-medium tracking-tight text-transparent md:text-7xl">
         Build lamps <br /> the right way
       </motion.h1>
     </LampContainer>
@@ -28,11 +28,11 @@ export const LampContainer = ({
   return (
     <div
       className={cn(
-        "relative flex min-h-screen flex-col items-center justify-center overflow-hidden bg-slate-950 w-full rounded-md z-0",
+        "relative flex min-h-screen flex-col items-center justify-start overflow-hidden bg-slate-950 w-full rounded-md z-0",
         className
       )}>
       <div
-        className="relative flex w-full flex-1 scale-y-125 items-center justify-center isolate z-0 ">
+        className="relative flex w-full flex-1 scale-y-125 items-center justify-start isolate z-0 ">
         <motion.div
           initial={{ opacity: 0.5, width: "15rem" }}
           whileInView={{ opacity: 1, width: "30rem" }}
@@ -95,7 +95,7 @@ export const LampContainer = ({
         <div
           className="absolute inset-auto z-40 h-44 w-full -translate-y-[12.5rem] bg-slate-950 "></div>
       </div>
-      <div className="relative z-50 flex -translate-y-80 flex-col items-center px-5">
+      <div className="relative z-50 flex flex-col items-center px-5">
         {children}
       </div>
     </div>


### PR DESCRIPTION
## Summary
- remove top offset classes on `LampDemo`
- align lamp container to header

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6840da54c43c832898fc8bd3a7ada3b8